### PR TITLE
Support unicode in README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 from blanc.__version__ import __version__
 
-with open("README.md") as reader:
+with open("README.md", encoding="utf-8") as reader:
     long_description = reader.read()
 
 with open("requirements.txt") as reader:


### PR DESCRIPTION
This ensures we can include unicode characters in the README properly, such as '…', accented characters, or… emoji!

See also https://github.com/PrimerAI/primer-nlx/pull/666