### PR TITLE
Run GHA workflow on our self hosted runners

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, cpu]
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
This will be slightly cheaper.